### PR TITLE
Cross Platform Support for getUserMedia

### DIFF
--- a/Assets/Plugins/WebGL/MicrophonePlugin.jslib
+++ b/Assets/Plugins/WebGL/MicrophonePlugin.jslib
@@ -13,6 +13,10 @@ var MicrophonePlugin = {
         }]
       }
     };
+    navigator.getUserMedia = ( navigator.getUserMedia ||
+				   navigator.webkitGetUserMedia ||
+				   navigator.mozGetUserMedia ||
+				   navigator.msGetUserMedia);
     navigator.getUserMedia(constraints, function(stream) {
       console.log('navigator.getUserMedia successCallback: ', stream);
 	  


### PR DESCRIPTION
getUserMedia isn't implemented by default on Firefox, as well as other browsers. This gives us that implementation inline so we don't get errors on loading in Firefox.